### PR TITLE
feat(ci): automate deployment to GitHub Pages via Actions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,43 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - run: npm ci
+
+      - run: npm run build
+        env:
+          NODE_ENV: production
+
+      - uses: actions/configure-pages@v5
+
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: build
+
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/package.json
+++ b/package.json
@@ -3,12 +3,12 @@
 	"version": "0.0.1",
 	"private": true,
 	"scripts": {
-		"dev": "set NODE_ENV=dev && vite dev",
-		"build": "set NODE_ENV=production && vite build",
+		"dev": "vite dev",
+		"build": "vite build",
 		"preview": "vite preview",
 		"check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
 		"check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
-        "deploy": "gh-pages -d build -t true"
+		"deploy": "gh-pages -d build -t true"
 	},
 	"devDependencies": {
 		"@sveltejs/adapter-auto": "^3.0.0",


### PR DESCRIPTION
## Summary

Automates the build and deploy process for the portfolio site using GitHub Actions. On push to `main`, the pipeline builds the SvelteKit static site and deploys to GitHub Pages without manual intervention.

## Changes

- **Fix cross-platform build scripts**: Removed Windows-only `set NODE_ENV=...` syntax from `package.json` scripts. The `NODE_ENV` is now set externally (via the workflow env block or shell prefix for local use).
- **Add deployment workflow**: Created `.github/workflows/deploy.yml` using artifact-based deployment (`actions/deploy-pages@v4`), which resolves the custom domain reset issue that occurs with branch-based deployment.

## How it works

1. Push to `main` triggers the workflow
2. Workflow installs dependencies (`npm ci`), builds with `NODE_ENV=production` (sets base path to `/t-industries`), and uploads the `build/` directory as a Pages artifact
3. `actions/deploy-pages` deploys the artifact to GitHub Pages
4. The `CNAME` file in `static/` ensures the custom domain (`t-industri.es`) is preserved

## One-time setup required

After merging, change the Pages source in repo settings:

1. **Settings → Pages → Source** → select **GitHub Actions**
2. Verify the custom domain field shows `t-industri.es`

## Testing

- `npm run build` builds successfully with empty base path (dev mode)
- `NODE_ENV=production npm run build` builds with `/t-industries` base path and includes `CNAME`
- Full end-to-end verification happens on first push to `main` after merge + settings change